### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,6 +1,9 @@
 
 name: CI/CD Pipeline
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/DJESolutions/CodeReview/security/code-scanning/1](https://github.com/DJESolutions/CodeReview/security/code-scanning/1)

To fix the issue, we will add a `permissions` key at the workflow level to define the least privileges required for the workflow. The `test` job only needs `contents: read` to check out the repository and run tests. The `deploy` job also requires `contents: read` to check out the repository and may need additional permissions for deployment-related actions. Since the deployment involves external APIs and does not modify the repository, no write permissions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
